### PR TITLE
Fix brand name typos

### DIFF
--- a/src/app/(dashboard)/user/likes/page.tsx
+++ b/src/app/(dashboard)/user/likes/page.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { UserLikesClient } from "@/components/dashboard/user/likes/UserLikesClient";
 
 export const metadata: Metadata = {
-  title: "Your Likes | MotorStix",
+  title: "Your Likes | MotoStix",
   description: "View all your liked products"
 };
 

--- a/src/app/(dashboard)/user/orders/page.tsx
+++ b/src/app/(dashboard)/user/orders/page.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { UserOrdersClient } from "@/components/dashboard/user/orders/UserOrdersClient";
 
 export const metadata: Metadata = {
-  title: "Your Orders | MotorStix",
+  title: "Your Orders | MotoStix",
   description: "View all your past orders"
 };
 

--- a/src/utils/generateReceiptPdf.ts
+++ b/src/utils/generateReceiptPdf.ts
@@ -19,7 +19,7 @@ export async function generateReceiptPdf(order: Order) {
     });
   };
 
-  drawText("MotorStix Order Receipt", 0, 18);
+  drawText("MotoStix Order Receipt", 0, 18);
   drawText(`Order ID: ${order.id}`, 30);
   drawText(`Customer: ${order.customerName} (${order.customerEmail})`, 50);
   drawText(`Status: ${order.status}`, 70);


### PR DESCRIPTION
## Summary
- update brand name to **MotoStix** in generated PDF
- update metadata titles in user orders and likes pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843819640c0832480bed37d36edc434