### PR TITLE
Implement rate limiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "resend": "^4.5.2",
+    "@upstash/redis": "^1.25.0",
     "server-only": "^0.0.1",
     "sonner": "^2.0.1",
     "stripe": "^18.0.0",

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const incrMock = jest.fn();
+const expireMock = jest.fn();
+const pexpireMock = jest.fn();
+const pttlMock = jest.fn();
+
+jest.mock('@upstash/redis', () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    incr: incrMock,
+    expire: expireMock,
+    pexpire: pexpireMock,
+    pttl: pttlMock
+  }))
+}));
+
+describe('rateLimit', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      UPSTASH_REDIS_REST_URL: 'url',
+      UPSTASH_REDIS_REST_TOKEN: 'token'
+    };
+    incrMock.mockReset();
+    expireMock.mockReset();
+    pexpireMock.mockReset();
+    pttlMock.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('allows requests under the limit', async () => {
+    incrMock.mockResolvedValue(1);
+    pttlMock.mockResolvedValue(1000);
+
+    const { rateLimit } = await import('./rateLimit');
+    const result = await rateLimit('user');
+
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(result.limit).toBe(5);
+    expect(expireMock).toHaveBeenCalled();
+  });
+
+  it('blocks requests over the limit', async () => {
+    incrMock.mockResolvedValue(6);
+    pttlMock.mockResolvedValue(500);
+
+    const { rateLimit } = await import('./rateLimit');
+    const result = await rateLimit('user');
+
+    expect(result.success).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.limit).toBe(5);
+  });
+});

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,33 +1,10 @@
 /**
  * Rate limiting utility using Upstash Redis
  *
- * TODO: Implement rate limiting when Redis is set up
- * Dependencies needed: @upstash/redis
- * Environment variables needed: UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
+ * Requires the `@upstash/redis` package and the environment variables
+ * `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to be set.
  */
 
-export interface RateLimitResult {
-  success: boolean;
-  limit?: number;
-  remaining?: number;
-  reset?: string;
-}
-
-export async function rateLimit(identifier: string): Promise<RateLimitResult> {
-  // TODO: Implement Redis-based rate limiting
-  // For now, allow all requests
-  console.warn("Rate limiting is not implemented yet. All requests are allowed.");
-
-  return {
-    success: true,
-    limit: 5,
-    remaining: 5,
-    reset: new Date(Date.now() + 60000).toISOString()
-  };
-}
-
-/* 
-// Future implementation with Redis:
 import { Redis } from "@upstash/redis";
 
 let redis: Redis | null = null;
@@ -41,6 +18,13 @@ try {
   }
 } catch (error) {
   console.error("Failed to initialize Redis:", error);
+}
+
+export interface RateLimitResult {
+  success: boolean;
+  limit?: number;
+  remaining?: number;
+  reset?: string;
 }
 
 export async function rateLimit(identifier: string): Promise<RateLimitResult> {
@@ -75,4 +59,3 @@ export async function rateLimit(identifier: string): Promise<RateLimitResult> {
     return { success: true };
   }
 }
-*/


### PR DESCRIPTION
## Summary
- install `@upstash/redis`
- implement Redis-based rate limit helper
- add tests for the rate limiter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2fe075c48324ac084ed2e07ccf14