### PR TITLE
Add support for multiple product images

### DIFF
--- a/src/components/dashboard/admin/products/AddProductForm.tsx
+++ b/src/components/dashboard/admin/products/AddProductForm.tsx
@@ -1320,6 +1320,7 @@ export function AddProductForm({ onSuccess }: ProductFormProps) {
           shippingClass: shippingClass || "standard",
           image: imageUrl, // Use the uploaded image URL
           additionalImages: additionalImageUrls.length > 0 ? additionalImageUrls : undefined,
+          images: [imageUrl, ...additionalImageUrls],
           averageRating: 0,
           reviewCount: 0
         };

--- a/src/components/dashboard/admin/products/UpdateProductForm.tsx
+++ b/src/components/dashboard/admin/products/UpdateProductForm.tsx
@@ -1232,7 +1232,8 @@ export function UpdateProductForm({ product }: UpdateProductFormProps) {
           shippingWeight: shippingWeight || undefined,
           shippingClass: shippingClass || "standard",
           image: imageUrl,
-          additionalImages: additionalImageUrls.length > 0 ? additionalImageUrls : undefined
+          additionalImages: additionalImageUrls.length > 0 ? additionalImageUrls : undefined,
+          images: [imageUrl, ...additionalImageUrls]
         };
 
         console.log("Submitting product data:", JSON.stringify(productData, null, 2));

--- a/src/components/products/page-detail/ProductGallery.tsx
+++ b/src/components/products/page-detail/ProductGallery.tsx
@@ -10,21 +10,26 @@ interface ProductGalleryProps {
 }
 
 export function ProductGallery({ product }: ProductGalleryProps) {
-  const [activeImage, setActiveImage] = useState(product.image || "/placeholder.svg");
-  // Add loading states
+  const imageList =
+    product.images && product.images.length > 0
+      ? product.images
+      : product.image
+        ? [product.image]
+        : ["/placeholder.svg"];
+
+  const [activeImage, setActiveImage] = useState(imageList[0]);
   const [isLoading, setIsLoading] = useState(true);
-  // TODO: Replace with real image gallery when product.images array is available
-  const imageList = [product.image || "/placeholder.svg"];
 
   return (
     <div className="space-y-4">
       {/* Main Image */}
       <div className="relative w-full aspect-square rounded-lg overflow-hidden bg-muted">
+        {isLoading && <div className="absolute inset-0 animate-pulse bg-muted" />}
         <Image
           src={activeImage}
           alt={product.name}
           fill
-          className="object-contain p-6"
+          className={`object-contain p-6 ${isLoading ? "hidden" : "block"}`}
           sizes="(max-width: 768px) 100vw, 500px"
           priority
           onLoad={() => setIsLoading(false)}
@@ -36,7 +41,10 @@ export function ProductGallery({ product }: ProductGalleryProps) {
         {imageList.map((img, i) => (
           <button
             key={i}
-            onClick={() => setActiveImage(img)}
+            onClick={() => {
+              setIsLoading(true);
+              setActiveImage(img);
+            }}
             className={`relative w-20 h-20 rounded-md overflow-hidden border-2 ${
               activeImage === img ? "border-primary" : "border-transparent"
             }`}>

--- a/src/firebase/admin/products.ts
+++ b/src/firebase/admin/products.ts
@@ -41,6 +41,8 @@ function mapDocToProduct(doc: FirebaseFirestore.DocumentSnapshot): Product {
     size: data?.size || "",
     image: data?.image || "/placeholder.svg",
     additionalImages: data?.additionalImages || [],
+    images: data?.images ||
+      (data?.image ? [data.image, ...(data?.additionalImages || [])] : data?.additionalImages || []),
     placements: data?.placements || [],
     price: data?.price || 0,
     salePrice: data?.salePrice || undefined,

--- a/src/schemas/product/product.ts
+++ b/src/schemas/product/product.ts
@@ -28,6 +28,7 @@ export const productSchema = z.object({
   /* Images */
   image: z.string().url("Image must be a valid URL").optional(),
   additionalImages: z.array(z.string().url("Must be a valid URL")).optional(),
+  images: z.array(z.string().url("Must be a valid URL")).optional(),
 
   /* Status flags */
   isFeatured: z.boolean().default(false).optional(),

--- a/src/types/product/product.ts
+++ b/src/types/product/product.ts
@@ -48,6 +48,7 @@ export interface Product {
   // Media
   image: string;
   additionalImages?: string[];
+  images?: string[];
   placements?: Placement[] | string[];
 
   // Pricing and Inventory
@@ -112,6 +113,7 @@ export interface SerializedProduct {
   // Media
   image: string;
   additionalImages?: string[];
+  images?: string[];
   placements?: Placement[] | string[];
 
   // Pricing and Inventory


### PR DESCRIPTION
## Summary
- extend `productSchema` and `Product` types with optional `images`
- return `images` from `mapDocToProduct`
- display thumbnails and loading state in `ProductGallery`
- populate `images` array in admin add/update product forms

## Testing
- `npm run test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b32dd7bb883249610cd53e6a336c2