### PR TITLE
Load site metadata from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+SITE_URL=http://localhost:3000
+SITE_TWITTER=https://twitter.com/example
+OG_IMAGE_URL=http://localhost:3000/og.jpg
 
 npm run dev
 

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -1,10 +1,16 @@
 // src/config/siteConfig.ts
 
+const isDev = process.env.NODE_ENV === "development";
+
+const SITE_URL = process.env.SITE_URL || (isDev ? "http://localhost:3000" : "https://motostix.com");
+const OG_IMAGE_URL = process.env.OG_IMAGE_URL || (isDev ? `${SITE_URL}/og.jpg` : "https://motostix.com/og.jpg");
+const SITE_TWITTER = process.env.SITE_TWITTER || (isDev ? "https://twitter.com/example" : "");
+
 export const siteConfig = {
   name: "MotoStix",
-  url: "https://motostix.com", // Replace with the actual URL
-  ogImage: "https://motostix.com/og.jpg", // Replace with the actual OG image URL
+  url: SITE_URL,
+  ogImage: OG_IMAGE_URL,
   description: "High-quality custom stickers for any surface or occasion.",
   keywords: ["custom stickers", "vinyl stickers", "waterproof stickers", "decals", "labels"],
-  twitter: "https://twitter.com/example" // Replace with the actual Twitter URL
+  twitter: SITE_TWITTER
 };


### PR DESCRIPTION
## Summary
- pull SITE_URL, SITE_TWITTER and OG_IMAGE_URL from environment variables with development defaults
- document the new environment variables in the README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b45b68b5483249f8c720651997627