### PR TITLE
Add env example and update setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_auth_domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+SITE_URL=http://localhost:3000
+SITE_TWITTER=https://twitter.com/example
+OG_IMAGE_URL=http://localhost:3000/og.jpg
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 .env.local
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Key folders to know:
 npm install
 ```
 
+3. Copy `.env.example` to `.env.local` and fill in your environment variables:
+
+```bash
+cp .env.example .env.local
+# then edit .env.local
+```
+
 NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_auth_domain
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id


### PR DESCRIPTION
## Summary
- add `.env.example` with environment variables
- allow `.env.example` to be tracked
- document copying `.env.example` to `.env.local`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4665893c83248f75ce56b85184b0