### PR TITLE
Enable extra product filters

### DIFF
--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -141,13 +141,43 @@ const ProductsPage = async ({ searchParams }: ProductsPageProps) => {
     // NEW: Extract the 'q' (search query) parameter
     const searchQuery = typeof resolvedSearchParams?.q === "string" ? resolvedSearchParams.q : undefined;
 
+    // Extract additional filter parameters
+    const parseBoolean = (value: string | string[] | undefined): boolean | undefined => {
+      if (typeof value === "string") return value === "true";
+      if (Array.isArray(value)) return value[0] === "true";
+      return undefined;
+    };
+
+    const parseArray = (value: string | string[] | undefined): string[] | undefined => {
+      if (typeof value === "string") {
+        return value.split(",").map(v => v.trim()).filter(v => v.length > 0);
+      }
+      if (Array.isArray(value)) {
+        return value
+          .flatMap(v => v.split(","))
+          .map(v => v.trim())
+          .filter(v => v.length > 0);
+      }
+      return undefined;
+    };
+
+    const designThemes = parseArray(resolvedSearchParams?.designThemes);
+    const onSale = parseBoolean(resolvedSearchParams?.onSale);
+    const isCustomizable = parseBoolean(resolvedSearchParams?.isCustomizable);
+
     console.log(
       "ProductsPage - Render. currentCategory from URL:",
       currentCategory,
       "currentSubcategory from URL:",
       currentSubcategory,
-      "searchQuery from URL:", // NEW: Log the search query
-      searchQuery
+      "searchQuery from URL:",
+      searchQuery,
+      "designThemes from URL:",
+      designThemes,
+      "onSale from URL:",
+      onSale,
+      "isCustomizable from URL:",
+      isCustomizable
     );
 
     // Fetch initial products
@@ -155,7 +185,10 @@ const ProductsPage = async ({ searchParams }: ProductsPageProps) => {
     const productsResult = await getAllProducts({
       category: currentCategory,
       subcategory: currentSubcategory,
-      query: searchQuery // Pass the search query
+      query: searchQuery,
+      designThemes,
+      onSale,
+      isCustomizable
     });
 
     const initialProducts = productsResult.success ? productsResult.data || [] : [];

--- a/src/config/homepage-categories.ts
+++ b/src/config/homepage-categories.ts
@@ -50,13 +50,13 @@ export const stickerGridSections = {
   customSection: {
     id: "custom",
     name: "Custom Designs",
-    url: "/products?custom=true",
+    url: "/products?isCustomizable=true",
     image: "/bike.jpg"
   },
   vintageSection: {
     id: "vintage",
     name: "Vintage Collection",
-    url: "/products?style=vintage",
+    url: "/products?designThemes=Vintage",
     image: "/car.jpg"
   }
 };


### PR DESCRIPTION
## Summary
- support `designThemes`, `onSale`, and `isCustomizable` URL params in products page
- update homepage links to use these new params

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx knip` *(fails: could not download package)*

------
https://chatgpt.com/codex/tasks/task_e_684d47b9d2c08324b51344307b4c27c2