### PR TITLE
Add Stripe Elements checkout flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ SITE_URL=http://localhost:3000
 SITE_TWITTER=https://twitter.com/example
 OG_IMAGE_URL=http://localhost:3000/og.jpg
 
+
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_
+STRIPE_SECRET_KEY=sk_test_

--- a/src/app/api/create-payment-intent/route.ts
+++ b/src/app/api/create-payment-intent/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { paymentIntentSchema } from "@/schemas/ecommerce/stripe";
+import { DEFAULT_CURRENCY } from "@/config/checkout";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2025-05-28.basil" });
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { amount, shipping } = paymentIntentSchema.parse(body);
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: Math.round(amount),
+      currency: DEFAULT_CURRENCY,
+      automatic_payment_methods: { enabled: true },
+      shipping: {
+        name: shipping.fullName,
+        phone: shipping.phone,
+        address: {
+          line1: shipping.address,
+          city: shipping.city,
+          state: shipping.state,
+          postal_code: shipping.zipCode,
+          country: shipping.country
+        }
+      },
+      receipt_email: shipping.email,
+      metadata: { email: shipping.email }
+    });
+
+    return NextResponse.json({ clientSecret: paymentIntent.client_secret });
+  } catch (error: any) {
+    console.error("[STRIPE_ERROR]", error);
+    return NextResponse.json({ error: error.message || "Failed to create payment intent." }, { status: 500 });
+  }
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/config/siteConfig";
+import { StripeProvider } from "@/providers/StripeProvider";
+import { CheckoutForm } from "@/components/checkout/CheckoutForm";
+
+export const metadata: Metadata = {
+  title: `Checkout | ${siteConfig.name}`,
+  description: "Complete your purchase securely with Stripe.",
+  robots: { index: false, follow: false }
+};
+
+export default function CheckoutPage() {
+  return (
+    <main className="min-h-screen">
+      <section className="py-12 md:py-16">
+        <StripeProvider>
+          <CheckoutForm />
+        </StripeProvider>
+      </section>
+    </main>
+  );
+}

--- a/src/components/cart/checkout-button.tsx
+++ b/src/components/cart/checkout-button.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2, ShoppingCart, Lock } from "lucide-react";
+import { ShoppingCart, Lock } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
 import { Button } from "@/components/ui/button";
 
 export function CheckoutButton() {
-  const [isLoading, setIsLoading] = useState(false);
   const { items, closeCart } = useCart();
   const { status } = useSession();
   const router = useRouter();
@@ -17,7 +15,7 @@ export function CheckoutButton() {
   const isAuthenticated = status === "authenticated";
   const isSessionLoading = status === "loading";
 
-  const handleCheckout = async () => {
+  const handleCheckout = () => {
     // If user is not authenticated, show a toast, close the cart, then redirect.
     if (!isAuthenticated) {
       // Add the toast notification right here
@@ -33,46 +31,13 @@ export function CheckoutButton() {
       return;
     }
 
-    setIsLoading(true);
-    try {
-      const response = await fetch("/api/checkout", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({ items })
-      });
-
-      if (response.status === 401) {
-        toast.error("You must be logged in to proceed.");
-        closeCart();
-        router.push("/login?callbackUrl=/cart");
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error("Failed to create checkout session.");
-      }
-
-      const { url } = await response.json();
-
-      if (url) {
-        window.location.href = url;
-      } else {
-        throw new Error("Could not retrieve checkout session URL.");
-      }
-    } catch (error: any) {
-      toast.error(error.message || "An error occurred during checkout.");
-    } finally {
-      setIsLoading(false);
-    }
+    closeCart();
+    router.push("/checkout");
   };
 
   return (
-    <Button onClick={handleCheckout} disabled={isLoading || isSessionLoading || items.length === 0} className="w-full">
-      {isSessionLoading ? (
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-      ) : !isAuthenticated ? (
+    <Button onClick={handleCheckout} disabled={isSessionLoading || items.length === 0} className="w-full">
+      {!isAuthenticated ? (
         <Lock className="mr-2 h-4 w-4" />
       ) : (
         <ShoppingCart className="mr-2 h-4 w-4" />

--- a/src/components/checkout/CheckoutForm.tsx
+++ b/src/components/checkout/CheckoutForm.tsx
@@ -1,0 +1,219 @@
+"use client";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useStripe, useElements, CardElement } from "@stripe/react-stripe-js";
+import { toast } from "sonner";
+
+import { shippingSchema, type ShippingFormValues } from "@/schemas/ecommerce/stripe";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useCart } from "@/contexts/CartContext";
+import { TAX_RATE, SHIPPING_CONFIG, DEFAULT_CURRENCY } from "@/config/checkout";
+import { CheckoutSummary } from "./checkout-summary";
+import { formatPrice } from "@/lib/utils";
+
+export function CheckoutForm() {
+  const stripe = useStripe();
+  const elements = useElements();
+  const { items, subtotal, clearCart } = useCart();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<ShippingFormValues>({
+    resolver: zodResolver(shippingSchema),
+    defaultValues: {
+      fullName: "",
+      email: "",
+      phone: "",
+      address: "",
+      city: "",
+      state: "",
+      zipCode: "",
+      country: ""
+    }
+  });
+
+  const tax = subtotal * TAX_RATE;
+  const shippingCost = subtotal > SHIPPING_CONFIG.freeShippingThreshold ? 0 : SHIPPING_CONFIG.flatRate;
+  const total = subtotal + tax + shippingCost;
+
+  async function onSubmit(values: ShippingFormValues) {
+    if (!stripe || !elements) return;
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/create-payment-intent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount: Math.round(total * 100), shipping: values })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create payment.");
+      const { error } = await stripe.confirmCardPayment(data.clientSecret, {
+        payment_method: {
+          card: elements.getElement(CardElement)!,
+          billing_details: {
+            name: values.fullName,
+            email: values.email,
+            phone: values.phone,
+            address: {
+              line1: values.address,
+              city: values.city,
+              state: values.state,
+              postal_code: values.zipCode,
+              country: values.country
+            }
+          }
+        },
+        shipping: {
+          name: values.fullName,
+          phone: values.phone,
+          address: {
+            line1: values.address,
+            city: values.city,
+            state: values.state,
+            postal_code: values.zipCode,
+            country: values.country
+          }
+        }
+      });
+      if (error) throw error;
+      clearCart();
+      window.location.href = "/checkout/success";
+    } catch (err: any) {
+      toast.error(err.message || "Payment failed.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (items.length === 0) {
+    return <p className="text-center">Your cart is empty.</p>;
+  }
+
+  return (
+    <div className="container mx-auto px-4">
+      <div className="grid md:grid-cols-2 gap-8">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="fullName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Full Name</FormLabel>
+                  <FormControl>
+                    <Input className="bg-background" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" className="bg-background" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Phone</FormLabel>
+                  <FormControl>
+                    <Input className="bg-background" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl>
+                    <Input className="bg-background" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="city"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>City</FormLabel>
+                    <FormControl>
+                      <Input className="bg-background" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="state"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>State</FormLabel>
+                    <FormControl>
+                      <Input className="bg-background" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="zipCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Zip Code</FormLabel>
+                    <FormControl>
+                      <Input className="bg-background" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="country"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Country</FormLabel>
+                    <FormControl>
+                      <Input className="bg-background" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="mt-4">
+              <CardElement options={{ style: { base: { fontSize: '16px' } } }} />
+            </div>
+            <Button type="submit" disabled={isSubmitting || !stripe} className="w-full">
+              {isSubmitting ? "Processing..." : `Pay ${formatPrice(total, DEFAULT_CURRENCY)}`}
+            </Button>
+          </form>
+        </Form>
+        <CheckoutSummary subtotal={subtotal} tax={tax} shipping={shippingCost} total={total} />
+      </div>
+    </div>
+  );
+}

--- a/src/providers/StripeProvider.tsx
+++ b/src/providers/StripeProvider.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { Elements } from "@stripe/react-stripe-js";
+import { loadStripe } from "@stripe/stripe-js";
+import type React from "react";
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+
+export function StripeProvider({ children }: { children: React.ReactNode }) {
+  return <Elements stripe={stripePromise}>{children}</Elements>;
+}


### PR DESCRIPTION
## Summary
- add Stripe publishable and secret keys to env example
- add Stripe Elements provider
- implement payment intent API route
- add checkout page and form using CardElement
- update cart checkout button to navigate to the new page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684d56d1139c832485201a9788282b29